### PR TITLE
Fixed compilation for ES5 target

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,8 +6,9 @@ export function promisify<A,A2,A3,A4,T>(f: (arg: A, arg2: A2, arg3: A3, arg4: A4
 
 export function promisify(f) {
     return function() {
+        var fargs = arguments; 
         return new Promise((resolve, reject) => {
-            var args = Array.prototype.slice.call(arguments);
+            var args = Array.prototype.slice.call(fargs);
             args.push((err, result) => err !== null ? reject(err) : resolve(result));
             f.apply(null, args);
         });
@@ -31,9 +32,10 @@ export function _try<T>(f: (arg: any, arg2: any, arg3: any) => T, arg: any, arg2
 export function _try<T>(f: (arg: any, arg2: any, arg3: any, arg4: any) => T, arg: any, arg2: any, arg3: any, arg4: any): Promise<T>;
 
 export function _try(f) {
+    var fargs = arguments;
     return new Promise((res, rej) => {
         try {
-            var args = Array.prototype.slice.call(arguments);
+            var args = Array.prototype.slice.call(fargs);
             args.shift();
             res(f.apply(null, args));
         } catch (err) {


### PR DESCRIPTION
When the TS compilation target is `es5` (as in `tsc --target es5 --lib es5,es2015.promise xxx.ts`), `tsc` outputs the following errors:

```
node_modules/typed-promisify/index.ts(10,51): error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.
node_modules/typed-promisify/index.ts(36,51): error TS2496: The 'arguments' object cannot be referenced in an arrow function in ES3 and ES5. Consider using a standard function expression.
```

This PR fixes that.