### PR TITLE
Handle undefined error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ export function promisify(f: any, thisContext?: any) {
     return function () {
         let args = Array.prototype.slice.call(arguments);
         return new Promise((resolve, reject) => {
-            args.push((err: any, result: any) => err !== null ? reject(err) : resolve(result));
+            args.push((err: any, result: any) => (err !== null && err !== undefined) ? reject(err) : resolve(result));
             f.apply(thisContext, args);
         });
     }

--- a/test.ts
+++ b/test.ts
@@ -8,6 +8,10 @@ describe('promisify', function() {
         cb(null, 'f');
     }
 
+    function fundefined(cb: Callback) {
+        cb(undefined, 'f');
+    }
+
     function fe(cb: Callback) {
         cb('error', null);
     }
@@ -29,6 +33,13 @@ describe('promisify', function() {
 
     it('function with no args', function() {
         return promisify(f)()
+        .then(res => {
+            assert.equal(res, 'f');
+        });
+    });
+
+    it('function with undefined', function() {
+        return promisify(fundefined)()
         .then(res => {
             assert.equal(res, 'f');
         });


### PR DESCRIPTION
If the callback used undefined instead of null, it got mistaken as an error. This fixes it